### PR TITLE
feat: add optimism mainnet support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,12 @@ NEXT_PUBLIC_LH_GATEWAY=
 NEXT_PUBLIC_INFURA_API_KEY=
 
 # Subgraph details to build goldsky subgraph url
+# Note: SUBGRAPH_PROJECT_ID is used as default for all chains in constants.ts
+# You can override per-chain by modifying the subgraphProjectId field in appConstants
 NEXT_PUBLIC_SUBGRAPH_VERSION=
 NEXT_PUBLIC_SUBGRAPH_PROJECT_ID=
+NEXT_PUBLIC_OPTIMISM_SUBGRAPH_PROJECT_ID=
+
 
 
 # Coordinator Service URL to generate poll result

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -1,4 +1,4 @@
-import { optimismSepolia, scrollSepolia, baseSepolia } from 'viem/chains';
+import { optimismSepolia, scrollSepolia, baseSepolia, optimism } from 'viem/chains';
 
 // First chain will be used as default chain by wagmi
-export const supportedChains = [optimismSepolia, scrollSepolia, baseSepolia] as const;
+export const supportedChains = [optimismSepolia, scrollSepolia, baseSepolia, optimism] as const;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,7 @@
 import { supportedChains } from '@/config/chains';
 import { PollPolicyType } from '@/types';
 import { Hex } from 'viem';
-import { baseSepolia, optimismSepolia, scrollSepolia } from 'viem/chains';
+import { baseSepolia, optimism, optimismSepolia, scrollSepolia } from 'viem/chains';
 
 export interface FaucetProvider {
   name: string;
@@ -22,11 +22,43 @@ export type ChainConstants = {
     infura: string;
     subgraph: string;
   };
+  subgraphProjectId: string;
+  isTestnet: boolean;
   supportedPolicies: PollPolicyType[];
-  faucets: FaucetProvider[];
+  faucets?: FaucetProvider[];
 };
 
 export const appConstants: Record<(typeof supportedChains)[number]['id'], ChainConstants> = {
+  // Mainnet
+  [optimism.id]: {
+    chain: optimism,
+    contracts: {
+      eas: '0x4200000000000000000000000000000000000021',
+      anonAadhaarVerifier: '0x45Db2e8649eaEB4D4c047bc790bd30Bc9e6C09f4',
+      semaphore: '0x',
+      gitcoinPassportDecoder: '0x5558D441779Eca04A329BcD6b47830D2C6607769'
+    },
+    slugs: {
+      eas: 'optimism',
+      coordinator: 'optimism',
+      infura: 'optimism',
+      subgraph: 'optimism'
+    },
+    subgraphProjectId: process.env.NEXT_PUBLIC_OPTIMISM_SUBGRAPH_PROJECT_ID || '',
+    isTestnet: false,
+    supportedPolicies: [
+      PollPolicyType.FreeForAll,
+      PollPolicyType.AnonAadhaar,
+      PollPolicyType.EAS,
+      PollPolicyType.ERC20,
+      PollPolicyType.ERC20Votes,
+      PollPolicyType.GitcoinPassport,
+      PollPolicyType.MerkleProof,
+      PollPolicyType.Token
+    ]
+  },
+
+  // Testnets
   [optimismSepolia.id]: {
     chain: optimismSepolia,
     contracts: {
@@ -41,6 +73,8 @@ export const appConstants: Record<(typeof supportedChains)[number]['id'], ChainC
       infura: 'optimism-sepolia',
       subgraph: 'optimism-sepolia'
     },
+    subgraphProjectId: process.env.NEXT_PUBLIC_SUBGRAPH_PROJECT_ID || '',
+    isTestnet: true,
     supportedPolicies: [
       PollPolicyType.FreeForAll,
       PollPolicyType.AnonAadhaar,
@@ -76,6 +110,8 @@ export const appConstants: Record<(typeof supportedChains)[number]['id'], ChainC
       infura: 'base-sepolia',
       subgraph: 'base-sepolia'
     },
+    subgraphProjectId: process.env.NEXT_PUBLIC_SUBGRAPH_PROJECT_ID || '',
+    isTestnet: true,
     supportedPolicies: [
       PollPolicyType.FreeForAll,
       PollPolicyType.AnonAadhaar,
@@ -110,6 +146,8 @@ export const appConstants: Record<(typeof supportedChains)[number]['id'], ChainC
       infura: 'scroll-sepolia',
       subgraph: 'scroll-sepolia'
     },
+    subgraphProjectId: process.env.NEXT_PUBLIC_SUBGRAPH_PROJECT_ID || '',
+    isTestnet: true,
     supportedPolicies: [
       PollPolicyType.FreeForAll,
       PollPolicyType.AnonAadhaar,

--- a/src/contexts/AppConstantsContext.tsx
+++ b/src/contexts/AppConstantsContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { supportedChains } from '@/config/chains';
 import { type ChainConstants, appConstants } from '@/config/constants';
-import { SUBGRAPH_PROJECT_ID, SUBGRAPH_VERSION } from '@/utils/constants';
+import { SUBGRAPH_VERSION } from '@/utils/constants';
 import { createContext, useEffect, useMemo, useState } from 'react';
 import { useChainId } from 'wagmi';
 
@@ -27,17 +27,17 @@ const AppConstantsProvider = ({ children }: { children: React.ReactNode }) => {
 
   const subgraphUrl = useMemo(() => {
     // Validate environment variables
-    if (!SUBGRAPH_PROJECT_ID || !SUBGRAPH_VERSION) {
+    if (!constants.subgraphProjectId || !SUBGRAPH_VERSION) {
       console.error('Missing subgraph environment variables:', {
-        SUBGRAPH_PROJECT_ID: SUBGRAPH_PROJECT_ID ? 'set' : 'missing',
+        subgraphProjectId: constants.subgraphProjectId ? 'set' : 'missing',
         SUBGRAPH_VERSION: SUBGRAPH_VERSION ? 'set' : 'missing'
       });
       // Return a fallback or throw an error
       throw new Error('Subgraph configuration is incomplete. Please check environment variables.');
     }
 
-    return `https://api.goldsky.com/api/public/${SUBGRAPH_PROJECT_ID}/subgraphs/privote-${constants.slugs.subgraph}/${SUBGRAPH_VERSION}/gn`;
-  }, [constants.slugs.subgraph]);
+    return `https://api.goldsky.com/api/public/${constants.subgraphProjectId}/subgraphs/privote-${constants.slugs.subgraph}/${SUBGRAPH_VERSION}/gn`;
+  }, [constants.subgraphProjectId, constants.slugs.subgraph]);
 
   const isChainSupported = supportedChains.some(chain => chain.id === shadowChain);
 

--- a/src/contexts/FaucetContext.tsx
+++ b/src/contexts/FaucetContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { FaucetModal } from '@/components/shared';
 import { supportedChains } from '@/config/chains';
+import { appConstants } from '@/config/constants';
 import { notification } from '@/utils/notification';
 import { PORTO_CONNECTOR_ID } from '@/utils/constants';
 import { createContext, useEffect, useState } from 'react';
@@ -39,9 +40,15 @@ const FaucetProvider = ({ children }: { children: React.ReactNode }) => {
       return true;
     }
 
+    const chainConstants = appConstants[chainId as (typeof supportedChains)[number]['id']];
+    const isTestnet = chainConstants?.isTestnet ?? false;
+
     if (!isLoading && balance && Number(balance.value) <= MIN_BALANCE) {
       notification.error('Insufficient balance');
-      setShowFaucetModal(true);
+      // Only show faucet modal for testnet chains
+      if (isTestnet) {
+        setShowFaucetModal(true);
+      }
 
       return true;
     }

--- a/src/contracts/deployedContracts.ts
+++ b/src/contracts/deployedContracts.ts
@@ -1,6 +1,991 @@
 import type { GenericContractsDeclaration } from './types';
 
 const deployedContracts = {
+  10: {
+    privote: {
+      address: '0xB95614009a5DaeCf0a4CEEAc68a0EC10BdF27255',
+      abi: [
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address',
+              name: '_policy',
+              type: 'address'
+            },
+            {
+              internalType: 'address',
+              name: '_initialVoiceCreditProxy',
+              type: 'address'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            }
+          ],
+          name: 'createPoll',
+          outputs: [
+            {
+              components: [
+                {
+                  internalType: 'address',
+                  name: 'poll',
+                  type: 'address'
+                },
+                {
+                  internalType: 'address',
+                  name: 'messageProcessor',
+                  type: 'address'
+                },
+                {
+                  internalType: 'address',
+                  name: 'tally',
+                  type: 'address'
+                }
+              ],
+              internalType: 'struct IMACI.PollContracts',
+              name: 'pollContracts',
+              type: 'tuple'
+            }
+          ],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_anonAadhaarVerifier',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256',
+              name: '_nullifierSeed',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithAnonAadhaar',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_easContract',
+              type: 'address'
+            },
+            {
+              internalType: 'address',
+              name: '_attester',
+              type: 'address'
+            },
+            {
+              internalType: 'bytes32',
+              name: '_schema',
+              type: 'bytes32'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithEAS',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_tokenAddress',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256',
+              name: '_threshold',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithERC20',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_tokenAddress',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256',
+              name: '_threshold',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_snapshotBlock',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithERC20Votes',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithFreeForAll',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_passportDecoder',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256',
+              name: '_thresholdScore',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithGitcoin',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_hatsProtocol',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256[]',
+              name: '_criterionHats',
+              type: 'uint256[]'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithHats',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'bytes32',
+              name: '_merkleRoot',
+              type: 'bytes32'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithMerkle',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_semaphoreContract',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256',
+              name: '_groupId',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithSemaphore',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'address',
+              name: '_tokenAddress',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithToken',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        },
+        {
+          inputs: [
+            {
+              internalType: 'string',
+              name: '_name',
+              type: 'string'
+            },
+            {
+              internalType: 'string[]',
+              name: '_options',
+              type: 'string[]'
+            },
+            {
+              internalType: 'bytes[]',
+              name: '_optionInfo',
+              type: 'bytes[]'
+            },
+            {
+              internalType: 'string',
+              name: '_metadata',
+              type: 'string'
+            },
+            {
+              internalType: 'uint256',
+              name: '_startTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_endTime',
+              type: 'uint256'
+            },
+            {
+              internalType: 'enum DomainObjs.Mode',
+              name: '_mode',
+              type: 'uint8'
+            },
+            {
+              components: [
+                {
+                  internalType: 'uint256',
+                  name: 'x',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'y',
+                  type: 'uint256'
+                }
+              ],
+              internalType: 'struct DomainObjs.PublicKey',
+              name: '_coordinatorPubKey',
+              type: 'tuple'
+            },
+            {
+              internalType: 'address[]',
+              name: '_relayers',
+              type: 'address[]'
+            },
+            {
+              internalType: 'uint256',
+              name: '_eventId',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_signer1',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: '_signer2',
+              type: 'uint256'
+            },
+            {
+              internalType: 'address',
+              name: '_verifier',
+              type: 'address'
+            },
+            {
+              internalType: 'uint256',
+              name: '_voiceCreditsBalance',
+              type: 'uint256'
+            }
+          ],
+          name: 'createPollWithZupass',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        }
+      ]
+    }
+  },
   11155420: {
     privote: {
       address: '0x250c7341E5651A3DF276A9f4fC6f9070226FeB32',

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -71,11 +71,11 @@ const usePoll = ({ pollAddress }: UsePollParams) => {
         // Generate all possible subgraph URLs
         const { supportedChains } = await import('@/config/chains');
         const { appConstants } = await import('@/config/constants');
-        const { SUBGRAPH_PROJECT_ID, SUBGRAPH_VERSION } = await import('@/utils/constants');
+        const { SUBGRAPH_VERSION } = await import('@/utils/constants');
 
         for (const chain of supportedChains) {
           const chainConstants = appConstants[chain.id];
-          const alternativeUrl = `https://api.goldsky.com/api/public/${SUBGRAPH_PROJECT_ID}/subgraphs/privote-${chainConstants.slugs.subgraph}/${SUBGRAPH_VERSION}/gn`;
+          const alternativeUrl = `https://api.goldsky.com/api/public/${chainConstants.subgraphProjectId}/subgraphs/privote-${chainConstants.slugs.subgraph}/${SUBGRAPH_VERSION}/gn`;
 
           // Skip if this is the same URL we already tried
           if (alternativeUrl === subgraphUrl) continue;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Optimism mainnet (chain 10) support, introduces per-chain subgraph project IDs, and limits faucet modal to testnets.
> 
> - **Chains/Config**:
>   - Add `optimism` to `supportedChains` and define `appConstants[optimism.id]` with contracts, slugs, `isTestnet=false`, and supported policies.
>   - Extend `ChainConstants` with `subgraphProjectId` and `isTestnet`; make `faucets` optional.
>   - Use per-chain `subgraphProjectId` in `AppConstantsContext` and `usePoll` for Goldsky URLs; add env `NEXT_PUBLIC_OPTIMISM_SUBGRAPH_PROJECT_ID` (and notes) in `.env.example`.
> - **Faucet Behavior**:
>   - Show faucet modal only on testnets using `appConstants[chainId].isTestnet`.
> - **Contracts**:
>   - Add deployed `privote` contract config for Optimism mainnet (`chainId 10`) with address and ABI in `src/contracts/deployedContracts.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02f47b3540ea764bac733e9854923cfd16cb8de9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->